### PR TITLE
Update yoga to support flex gap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ wasm:
 		-g0 \
 		-O2 \
 		-flto \
-		--closure 1 \
 		-msimd128 \
 		-s WASM=1 \
 		-s WASM_ASYNC_COMPILATION=1 \

--- a/bindings/Node.cc
+++ b/bindings/Node.cc
@@ -212,6 +212,10 @@ void Node::setPaddingPercent(int edge, double padding) {
   YGNodeStyleSetPaddingPercent(m_node, static_cast<YGEdge>(edge), padding);
 }
 
+void Node::setGap(int gutter, double gapLength) {
+  YGNodeStyleSetGap(m_node, static_cast<YGGutter>(gutter), gapLength);
+}
+
 int Node::getPositionType(void) const {
   return YGNodeStyleGetPositionType(m_node);
 }
@@ -302,6 +306,10 @@ double Node::getBorder(int edge) const {
 
 YGValue Node::getPadding(int edge) const {
   return YGNodeStyleGetPadding(m_node, static_cast<YGEdge>(edge));
+}
+
+double Node::getGap(int gutter) {
+  return YGNodeStyleGetGap(m_node, static_cast<YGGutter>(gutter));
 }
 
 void Node::insertChild(Node* child, unsigned index) {

--- a/bindings/Node.hh
+++ b/bindings/Node.hh
@@ -117,6 +117,8 @@ public: // Style setters
   void setPadding(int edge, double padding);
   void setPaddingPercent(int edge, double padding);
 
+  void setGap(int gutter, double gapLength);
+
 public: // Style getters
   int getPositionType(void) const;
   YGValue getPosition(int edge) const;
@@ -151,6 +153,8 @@ public: // Style getters
   double getBorder(int edge) const;
 
   YGValue getPadding(int edge) const;
+  
+  double getGap(int gutter);
 
 public: // Tree hierarchy mutators
   void insertChild(Node* child, unsigned index);

--- a/bindings/embind.cc
+++ b/bindings/embind.cc
@@ -21,6 +21,12 @@ EMSCRIPTEN_BINDINGS(YGEnums) {
     .value("percent", YGUnitPercent)
     .value("auto", YGUnitAuto)
   ;
+
+  enum_<YGGutter>("YGGutter")
+    .value("column", YGGutterColumn)
+    .value("row", YGGutterRow)
+    .value("all", YGGutterAll)
+  ;
 }
 
 EMSCRIPTEN_BINDINGS(Config) {
@@ -121,6 +127,7 @@ EMSCRIPTEN_BINDINGS(Node) {
 
     .function("setPadding", &Node::setPadding)
     .function("setPaddingPercent", &Node::setPaddingPercent)
+    .function("setGap", &Node::setGap)
 
     .function("getPositionType", &Node::getPositionType)
     .function("getPosition", &Node::getPosition)
@@ -155,6 +162,7 @@ EMSCRIPTEN_BINDINGS(Node) {
     .function("getDisplay", &Node::getDisplay)
 
     .function("getPadding", &Node::getPadding)
+    .function("getGap", &Node::getGap)
 
     .function("insertChild", &Node::insertChild, allow_raw_pointers())
     .function("removeChild", &Node::removeChild, allow_raw_pointers())

--- a/build.js
+++ b/build.js
@@ -15,7 +15,7 @@ async function start() {
     outfile: './dist/entry.js',
     external: ['*.wasm'],
     minify: true,
-    plugins: [flow(/\.js$/)],
+    plugins: [flow(/\.js$/, true)],
   })
 
   await build({
@@ -30,7 +30,7 @@ async function start() {
     outfile: './dist/index.js',
     external: ['*.wasm', './entry.js', './yoga.mjs'],
     minify: true,
-    plugins: [flow(/\.js$/)],
+    plugins: [flow(/\.js$/, true)],
   })
 
   // Here a trick to avoid initializing the URL for the wasm file. Doing this

--- a/entry/index.js
+++ b/entry/index.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-const CONSTANTS = require('../yoga/javascript/sources/YGEnums')
+import CONSTANTS from '../yoga/javascript/sources/YGEnums'
 import type {
   Yoga$Edge,
   Yoga$FlexWrap,
@@ -20,6 +20,7 @@ import type {
   Yoga$JustifyContent,
   Yoga$Display,
   Yoga$ExperimentalFeature,
+  Yoga$Gutter,
 } from '../yoga/javascript/sources/YGEnums'
 
 class Layout {
@@ -163,6 +164,7 @@ export type Yoga$Node = {
   getPosition(edge: Yoga$Edge): Value,
   getPositionType(): Yoga$PositionType,
   getWidth(): Value,
+  getGap(gutter: Yoga$Gutter): Value,
   insertChild(child: Yoga$Node, index: number): void,
   isDirty(): boolean,
   markDirty(): void,
@@ -200,6 +202,7 @@ export type Yoga$Node = {
   setOverflow(overflow: Yoga$Overflow): void,
   setPadding(edge: Yoga$Edge, padding: number | string): void,
   setPaddingPercent(edge: Yoga$Edge, padding: number): void,
+  setGap(gutter: Yoga$Gutter, gapLength: number): void,
   setPosition(edge: Yoga$Edge, position: number | string): void,
   setPositionPercent(edge: Yoga$Edge, position: number): void,
   setPositionType(positionType: Yoga$PositionType): void,


### PR DESCRIPTION
I manage to build a fresh version of yoga

- I saw comments that `absolute` position doesn't work, I think it was broken because of outdated constants in `YGEnums.js` file. it was fixed here https://github.com/facebook/yoga/commit/5a18ccdbe2f9363ddbe2d0bb78f3a7add2bc3ff8#diff-e7e9b48fa242a44e79d3aba89325057e4014f3acc7b0c14e808519acfb2ab225R86-R89
 