### PR TITLE
Asm is back

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC=emcc
 
-all: clean dir wasm
+all: clean dir wasm asm
 
 wasm:
 	$(CC) yoga/yoga/*.cpp bindings/*.cc \
@@ -19,12 +19,35 @@ wasm:
 		-s DYNAMIC_EXECUTION=0 \
 		-s TEXTDECODER=0 \
 		-s ENVIRONMENT='web' \
-		-s ERROR_ON_UNDEFINED_SYMBOLS=0 \
 		-s FILESYSTEM=0 \
 		-s MALLOC="emmalloc" \
 		-s INCOMING_MODULE_JS_API=['instantiateWasm','locateFile']\
 		-s EXPORT_NAME="yoga" \
 		-o tmp/yoga.mjs
+
+asm:
+	$(CC) yoga/yoga/*.cpp bindings/*.cc \
+		--bind \
+		-Iyoga \
+		-g0 \
+		-Os \
+		-flto \
+		--memory-init-file 0 \
+		-s WASM=0 \
+		-s WASM_ASYNC_COMPILATION=0 \
+		-s USE_CLOSURE_COMPILER=1 \
+		-s USE_ES6_IMPORT_META=0 \
+		-s ASSERTIONS=0 \
+		-s ALLOW_MEMORY_GROWTH=1 \
+		-s MODULARIZE=1 \
+		-s DYNAMIC_EXECUTION=0 \
+		-s TEXTDECODER=0 \
+		-s ENVIRONMENT='web' \
+		-s ERROR_ON_UNDEFINED_SYMBOLS=0 \
+		-s FILESYSTEM=0 \
+		-s MALLOC="emmalloc" \
+		-s EXPORT_NAME="yoga" \
+		-o tmp/yoga-asm.mjs
 
 clean:
 	rm -rf tmp 

--- a/asm.js
+++ b/asm.js
@@ -1,0 +1,10 @@
+import entry from './entry/index.js'
+import yoga from './tmp/yoga-asm.mjs'
+
+function bind(_, proto) {
+  return proto
+}
+
+export default function () {
+  return entry(bind, yoga())
+}

--- a/build.js
+++ b/build.js
@@ -3,6 +3,20 @@ import { build } from 'esbuild'
 import flow from 'esbuild-plugin-flow'
 
 async function start() {
+  const asm = build({
+    bundle: true,
+    sourcemap: false,
+    format: 'esm',
+    target: 'esnext',
+    loader: {
+      '.js': 'ts',
+    },
+    entryPoints: ['./asm.js'],
+    outfile: './dist/asm.js',
+    minify: true,
+    plugins: [flow(/\.js$/, true)],
+  })
+
   await build({
     bundle: true,
     sourcemap: false,
@@ -18,6 +32,7 @@ async function start() {
   })
 
   await copyFile('./tmp/yoga.wasm', './dist/yoga.wasm')
+  await asm
 }
 
 start()

--- a/package.json
+++ b/package.json
@@ -1,10 +1,14 @@
 {
   "name": "yoga-wasm-web",
   "version": "0.2.0",
-  "main": "dist/index.js",
   "types": "index.d.ts",
   "typings": "index.d.ts",
   "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./dist/index.js",
+    "./asm": "./dist/asm.js"
+  },
   "scripts": {
     "build": "make && node build.js"
   },


### PR DESCRIPTION
I returned back `asm` build.

It is synchronous now to be fully compatible with `yoga-layout-prebuild`, it is `20kb` gzip less than the old `nbind` version and I hope it works (will create tests after #5 would be merged)