### PR TITLE
add wasm file to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "exports": {
     "./package.json": "./package.json",
+    "./dist/yoga.wasm": "./dist/yoga.wasm",
     ".": "./dist/index.js",
     "./asm": "./dist/asm.js"
   },


### PR DESCRIPTION
- to avoid problems with resolving `.wasm` in modern bundlers