### PR TITLE
support NodeNext module resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,7 @@ yarn.lock
 .vscode
 
 build
-dist
 tmp
+dist/*
+!dist/index.d.ts
+!dist/asm.d.ts

--- a/asm.d.ts
+++ b/asm.d.ts
@@ -1,6 +1,0 @@
-import type { Yoga } from "./wrapAsm";
-
-export * from "./generated/YGEnums";
-export * from "./wrapAsm";
-
-export default function (): Yoga;

--- a/dist/asm.d.ts
+++ b/dist/asm.d.ts
@@ -1,0 +1,6 @@
+import type { Yoga } from "./wrapAsm.js";
+
+export * from "./generated/YGEnums.js";
+export * from "./wrapAsm.js";
+
+export default function (): Yoga;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,7 +1,7 @@
-import type { Yoga } from "./dist/wrapAsm";
+import type { Yoga } from "./wrapAsm.js";
 
-export * from "./dist/generated/YGEnums";
-export * from "./dist/wrapAsm";
+export * from "./generated/YGEnums.js";
+export * from "./wrapAsm.js";
 
 export default function (wasm: ArrayBuffer): Promise<Yoga>;
 export function initStreaming(response: Response): Promise<Yoga>;

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "yoga-wasm-web",
-  "version": "0.3.2",
+  "version": "0.3.1",
   "types": "dist/index.d.ts",
-  "typings": "dist/index.d.ts",
   "type": "module",
   "exports": {
     "./package.json": "./package.json",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "yoga-wasm-web",
-  "version": "0.3.1",
-  "types": "index.d.ts",
-  "typings": "index.d.ts",
+  "version": "0.3.2",
+  "types": "dist/index.d.ts",
+  "typings": "dist/index.d.ts",
   "type": "module",
   "exports": {
     "./package.json": "./package.json",
@@ -21,7 +21,6 @@
   "files": [
     "dist",
     "package.json",
-    "index.d.ts",
     "LICENSE"
   ],
   "devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,7 +13,6 @@ await copyFile(
   "./yoga/javascript/src_js/generated/YGEnums.d.ts",
   "./dist/generated/YGEnums.d.ts"
 );
-await copyFile("./asm.d.ts", "./dist/asm.d.ts");
 
 export default [
   {

--- a/test/defaults.test.ts
+++ b/test/defaults.test.ts
@@ -83,7 +83,7 @@ describe("defaults", () => {
   it("CONSTANTS is exported from root entry", async () => {
     const { EDGE_END, DISPLAY_NONE, GUTTER_ALL } = process.env.ASM
       ? await import("../dist/asm")
-      : await import("..");
+      : await import("../dist");
 
     expect(EDGE_END).toBeDefined();
     expect(DISPLAY_NONE).toBeDefined();

--- a/test/init.ts
+++ b/test/init.ts
@@ -2,7 +2,6 @@ import { readFile } from "node:fs/promises";
 import process from "node:process";
 
 import initWasm from "../dist";
-// for some reason Vite doesn't use export maps here, and resolves to source code
 import initAsm from "../dist/asm";
 
 export const Yoga = process.env.ASM

--- a/test/init.ts
+++ b/test/init.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import process from "node:process";
 
-import initWasm from "..";
+import initWasm from "../dist";
 // for some reason Vite doesn't use export maps here, and resolves to source code
 import initAsm from "../dist/asm";
 


### PR DESCRIPTION
The placement of the *.d.ts files currently prevents support for projects that use the NodeNext module resolution since the .d.ts are expected to be placed with their definitions. Additionally, the .js file ending is expected. The changes in this PR should enable both the current node moduleResolution and the NodeNext moduleResolution.