### PR TITLE
feat: Improve argument types of initialize functions

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -3,5 +3,5 @@ import type { Yoga } from "./wrapAsm.js";
 export * from "./generated/YGEnums.js";
 export * from "./wrapAsm.js";
 
-export default function (wasm: ArrayBuffer): Promise<Yoga>;
-export function initStreaming(response: Response): Promise<Yoga>;
+export default function (wasm: ArrayBuffer | WebAssembly.Module): Promise<Yoga>;
+export function initStreaming(response: Response | PromiseLike<Response>): Promise<Yoga>;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -3,5 +3,5 @@ import type { Yoga } from "./wrapAsm.js";
 export * from "./generated/YGEnums.js";
 export * from "./wrapAsm.js";
 
-export default function (wasm: ArrayBuffer | WebAssembly.Module): Promise<Yoga>;
+export default function (wasm: BufferSource | WebAssembly.Module): Promise<Yoga>;
 export function initStreaming(response: Response | PromiseLike<Response>): Promise<Yoga>;

--- a/index.js
+++ b/index.js
@@ -6,8 +6,12 @@ export * from "./yoga/javascript/src_js/generated/YGEnums.js";
 export default async function (wasm) {
   const mod = await yoga({
     instantiateWasm(info, receive) {
-      WebAssembly.instantiate(wasm, info).then(({ instance }) => {
-        receive(instance);
+      WebAssembly.instantiate(wasm, info).then((instance) => {
+        if (instance instanceof WebAssembly.Instance) {
+          receive(instance);
+        } else {
+          receive(instance.instance);
+        }
       });
     },
   });


### PR DESCRIPTION
Although `WebAssembly.instantiate()` can accept `BufferSource` (`ArrayBuffer | ArrayBufferView`) and `WebAssembly.Module`, this library only accepts `ArrayBuffer` is the only one accepted. So I made it so that it accepts `BufferSource` and `WebAssembly.Module` with `initYoga`.
This may help with things like CF Workers where only compiled WASM is available.

ref:
- https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/instantiate
- https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/instantiateStreaming