### PR TITLE
refactor: use global `require` if available

### DIFF
--- a/node.js
+++ b/node.js
@@ -2,8 +2,13 @@ import { readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import initYoga from "./index.js";
 
+const _require = 
+  typeof require === "undefined" 
+    ? createRequire(import.meta.url) 
+    : require;
+
 const Yoga = await initYoga(
-  await readFile(createRequire(import.meta.url).resolve("./yoga.wasm"))
+  await readFile(_require.resolve("./yoga.wasm"))
 );
 
 export * from "./yoga/javascript/src_js/generated/YGEnums.js";


### PR DESCRIPTION
Though Ink would need to update as well for this to have an impact on the linked issues, **when shimming require, we should respect the global require if it exists** so it plays nice with bundlers. 

- https://github.com/oven-sh/bun/issues/13405
- https://github.com/oven-sh/bun/issues/6567
- https://github.com/oven-sh/bun/issues/2034